### PR TITLE
Add the ability to not create a Repo with Database

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -3,186 +3,196 @@ var shelljs = require('shelljs');
 var chalk = require('chalk');
 
 module.exports = class extends Generator {
-  // Helper methods
-  _buildConfiguration(answers) {
-    var configuration = {};
+    // Helper methods
+    _buildConfiguration(answers) {
+        var configuration = {};
 
-    for (var answer in answers) {
-      if (answers.hasOwnProperty(answer)) {
-        configuration[answer] = answers[answer];
-      }
+        for (var answer in answers) {
+            if (answers.hasOwnProperty(answer)) {
+                configuration[answer] = answers[answer];
+            }
+        }
+
+        return configuration;
     }
 
-    return configuration;
-  }
+    _folders(configuration) {
+        var defaultPackage = configuration.defaultPackage;
+        var defaultPackageFolder = defaultPackage.replace(/\./g, '/');
 
-  _folders(configuration) {
-    var defaultPackage = configuration.defaultPackage;
-    var defaultPackageFolder = defaultPackage.replace(/\./g, '/');
+        return {
+            main: {
+                java: 'src/main/java/' + defaultPackageFolder + '/',
+                resources: 'src/main/resources/'
+            },
+            test: {
+                java: 'src/test/java/' + defaultPackageFolder + '/',
+                resources: 'src/test/resources/'
+            },
+        };
+    }
 
-    return {
-      main: {
-        java: 'src/main/java/' + defaultPackageFolder + '/',
-        resources: 'src/main/resources/'
-      },
-      test: {
-        java: 'src/test/java/' + defaultPackageFolder + '/',
-        resources: 'src/test/resources/'
-      },
-    };
-  }
+    // Task methods
+    initializing() {
+        var banner = "\n" +
+            "  __  __                _     _       _        \n" +
+            " |  \\/  | __ _  ___ ___| |__ (_) __ _| |_ ___  \n" +
+            " | |\\/| |/ _` |/ __/ __| '_ \\| |/ _` | __/ _ \\ \n" +
+            " | |  | | (_| | (_| (__| | | | | (_| | || (_) |\n" +
+            " |_|  |_|\\__,_|\\___\\___|_| |_|_|\\__,_|\\__\\___/ \n" +
+            "                                               \n";
+        this.log(chalk.green(banner));
+    }
 
-  // Task methods
-  initializing() {
-    var banner ="\n" +
-                "  __  __                _     _       _        \n" +
-                " |  \\/  | __ _  ___ ___| |__ (_) __ _| |_ ___  \n" +
-                " | |\\/| |/ _` |/ __/ __| '_ \\| |/ _` | __/ _ \\ \n" +
-                " | |  | | (_| | (_| (__| | | | | (_| | || (_) |\n" +
-                " |_|  |_|\\__,_|\\___\\___|_| |_|_|\\__,_|\\__\\___/ \n" +
-                "                                               \n";
-    this.log(chalk.green(banner));
-  }
+    prompting() {
+        var questions = [
+            {
+                type: "input",
+                name: "applicationName",
+                message: "What's your application name?"
+            },
+            {
+                type: "input",
+                name: "defaultPackage",
+                message: "What's the default package name?"
+            },
+            {
+                type: "input",
+                name: "timeZone",
+                message: "What is the application time zone?",
+                default: 'UTC'
+            },
+            {
+                type: "list",
+                name: "dbType",
+                choices: ["jpa", "jdbc", "none"],
+                message: "Do you want to use JPA or JDBC?"
+            }
+        ];
 
-  prompting() {
-    var questions = [
-      {
-        type: "input",
-        name: "applicationName",
-        message: "What's your application name?"
-      },
-      {
-        type: "input",
-        name: "defaultPackage",
-        message: "What's the default package name?"
-      },
-      {
-        type: "input",
-        name: "timeZone",
-        message: "What is the application time zone?",
-        default: 'UTC'
-      },
-       {
-         type: "list",
-         name: "dbType",
-         choices:["jpa","jdbc"],
-         message: "Do you want to use JPA or JDBC?"
+        return this
+            .prompt(questions)
+            .then((answers) => {
+            this.configuration = this._buildConfiguration(answers);
+    });}
+
+    writing() {
+        var folders = this._folders(this.configuration);
+
+        this.fs.copyTpl(
+            this.templatePath('Procfile'),
+            this.destinationPath('Procfile'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
+            this.templatePath('gitignore'),
+            this.destinationPath('.gitignore'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
+            this.templatePath('travis.yml'),
+            this.destinationPath('.travis.yml'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
+            this.templatePath('java/Application.java'),
+            this.destinationPath(folders.main.java + 'Application.java'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
+            this.templatePath('java/ClockConfiguration.java'),
+            this.destinationPath(folders.main.java + '/config/ClockConfiguration.java'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
+            this.templatePath('java/PropertiesConfiguration.java'),
+            this.destinationPath(folders.main.java + '/config/PropertiesConfiguration.java'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
+            this.templatePath('resources/application.properties'),
+            this.destinationPath(folders.main.resources + 'application.properties'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
+            this.templatePath('resources/application-local.properties'),
+            this.destinationPath(folders.main.resources + 'application-local.properties'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
+            this.templatePath('resources/application-test.properties'),
+            this.destinationPath(folders.test.resources + 'application-test.properties'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
+            this.templatePath('java/ApplicationTest.java'),
+            this.destinationPath(folders.test.java + 'ApplicationTest.java'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
+            this.templatePath('build.gradle'),
+            this.destinationPath('build.gradle'),
+            this.configuration
+        );
+        if (this.configuration['dbType'] == 'none') {
+            this.fs.copyTpl(
+                this.templatePath('gradle/scripts/java.gradle'),
+                this.destinationPath('gradle/scripts/java.gradle'),
+                this.configuration
+            );
+            this.fs.copyTpl(
+                this.templatePath('gradle/scripts/spring-boot.gradle'),
+                this.destinationPath('gradle/scripts/spring-boot.gradle'),
+                this.configuration
+            );
+        } else {
+            this.fs.copyTpl(
+                this.templatePath('gradle/scripts/*.gradle'),
+                this.destinationPath('gradle/scripts/'),
+                this.configuration
+            );
         }
-    ];
+        this.fs.copyTpl(
+            this.templatePath('java/advice/*.java'),
+            this.destinationPath(folders.main.java + '/advice/'),
+            this.configuration
+        );
 
-    return this
-      .prompt(questions)
-      .then((answers) => {
-        this.configuration = this._buildConfiguration(answers);
-      });
-  }
+        this.fs.copyTpl(
+            this.templatePath('java/annotation/*.java'),
+            this.destinationPath(folders.main.java + '/annotation/'),
+            this.configuration
+        );
 
-  writing() {
-    var folders = this._folders(this.configuration);
+        this.fs.copyTpl(
+            this.templatePath('resources/logback.xml'),
+            this.destinationPath(folders.main.resources + 'logback.xml'),
+            this.configuration
+        );
 
-    this.fs.copyTpl(
-      this.templatePath('Procfile'),
-      this.destinationPath('Procfile'),
-      this.configuration
-    );
+        this.fs.copyTpl(
+            this.templatePath('resources/flyway/*.sql'),
+            this.destinationPath(folders.main.resources + '/db/migration/'),
+            this.configuration
+        );
+    }
 
-    this.fs.copyTpl(
-      this.templatePath('gitignore'),
-      this.destinationPath('.gitignore'),
-      this.configuration
-    );
+    install() {
+        this.log(chalk.green('Building your workspace'));
+        shelljs.exec('gradle wrapper --gradle-version 4.0', {silent: true});
 
-    this.fs.copyTpl(
-      this.templatePath('travis.yml'),
-      this.destinationPath('.travis.yml'),
-      this.configuration
-    );
-
-    this.fs.copyTpl(
-      this.templatePath('java/Application.java'),
-      this.destinationPath(folders.main.java + 'Application.java'),
-      this.configuration
-    );
-
-    this.fs.copyTpl(
-      this.templatePath('java/ClockConfiguration.java'),
-      this.destinationPath(folders.main.java + '/config/ClockConfiguration.java'),
-      this.configuration
-    );
-
-    this.fs.copyTpl(
-      this.templatePath('java/PropertiesConfiguration.java'),
-      this.destinationPath(folders.main.java + '/config/PropertiesConfiguration.java'),
-      this.configuration
-    );
-
-    this.fs.copyTpl(
-      this.templatePath('resources/application.properties'),
-      this.destinationPath(folders.main.resources + 'application.properties'),
-      this.configuration
-    );
-
-    this.fs.copyTpl(
-      this.templatePath('resources/application-local.properties'),
-      this.destinationPath(folders.main.resources + 'application-local.properties'),
-      this.configuration
-    );
-
-    this.fs.copyTpl(
-      this.templatePath('resources/application-test.properties'),
-      this.destinationPath(folders.test.resources + 'application-test.properties'),
-      this.configuration
-    );
-
-    this.fs.copyTpl(
-      this.templatePath('java/ApplicationTest.java'),
-      this.destinationPath(folders.test.java + 'ApplicationTest.java'),
-      this.configuration
-    );
-
-    this.fs.copyTpl(
-      this.templatePath('build.gradle'),
-      this.destinationPath('build.gradle'),
-      this.configuration
-    );
-
-      this.fs.copyTpl(
-          this.templatePath('gradle/scripts/*.gradle'),
-          this.destinationPath('gradle/scripts/'),
-          this.configuration
-      );
-
-      this.fs.copyTpl(
-          this.templatePath('java/advice/*.java'),
-          this.destinationPath(folders.main.java + '/advice/'),
-          this.configuration
-      );
-
-      this.fs.copyTpl(
-          this.templatePath('java/annotation/*.java'),
-          this.destinationPath(folders.main.java + '/annotation/'),
-          this.configuration
-      );
-
-      this.fs.copyTpl(
-          this.templatePath('resources/logback.xml'),
-          this.destinationPath(folders.main.resources + 'logback.xml'),
-          this.configuration
-      );
-
-      this.fs.copyTpl(
-          this.templatePath('resources/flyway/*.sql'),
-          this.destinationPath(folders.main.resources + '/db/migration/'),
-          this.configuration
-      );
-  }
-
-  install() {
-    this.log(chalk.green('Building your workspace'));
-    shelljs.exec('gradle wrapper --gradle-version 4.0', {silent: true});
-
-    shelljs.exec('git init', {silent: true});
-    shelljs.exec('git add .', {silent: true});
-    shelljs.exec('git commit -m "Initial commit"', {silent: true});
-  }
+        shelljs.exec('git init', {silent: true});
+        shelljs.exec('git add .', {silent: true});
+        shelljs.exec('git commit -m "Initial commit"', {silent: true});
+    }
 };

--- a/generators/app/templates/build.gradle
+++ b/generators/app/templates/build.gradle
@@ -24,10 +24,11 @@ dependencies {
 
   compile('org.springframework.boot:spring-boot-starter-actuator')
   <% if(dbType == "jpa") {%>compile('org.springframework.boot:spring-boot-starter-data-jpa')
-  <%}else{%>
-  compile('org.springframework.boot:spring-boot-starter-jdbc')<%}%>
+  <%}else{ if(dbType == "jdbc"){%>
+  compile('org.springframework.boot:spring-boot-starter-jdbc')<%}}%>
+  <% if(dbType != "none") {%>
   compile('org.postgresql:postgresql:42.1.1')
-
+          <%}%>
   testCompile('org.springframework.boot:spring-boot-starter-test')
   testCompile('org.assertj:assertj-core:3.4.0')
   testCompile('com.jayway.jsonpath:json-path:2.2.0')

--- a/generators/app/templates/gradle/scripts/spring-boot.gradle
+++ b/generators/app/templates/gradle/scripts/spring-boot.gradle
@@ -2,9 +2,10 @@ apply plugin: 'org.springframework.boot'
 
 bootRun {
   environment SPRING_PROFILES_ACTIVE: environment.SPRING_PROFILES_ACTIVE ?: 'local'
-
+  <% if(dbType == "jpa") {%>
   if(environment.SPRING_PROFILES_ACTIVE == 'local') {
     dependsOn 'startPostgresDocker'
     finalizedBy 'stopPostgresDocker'
   }
+   <%}%>
 }


### PR DESCRIPTION
Sometimes when someone needs to create a project just to experiment new
stuff, or access remote endpoints it's not needed a database, and use a
template that creates all files and integrations with a database it's
over engineering. In this commit it's add a new option on checkbox to
the question of `Which type of database do you want to use?` that is
"none".

<img width="433" alt="screen shot 2017-07-16 at 12 35 04" src="https://user-images.githubusercontent.com/7951799/28248935-651095f6-6a23-11e7-9ab6-5ee59010c1ee.png">
