### PR TITLE
Add Rest Generator

### DIFF
--- a/generators/app/templates/build.gradle
+++ b/generators/app/templates/build.gradle
@@ -18,6 +18,7 @@ dependencies {
   compile('org.springframework.boot:spring-boot-starter-aop')
   compile('org.springframework.boot:spring-boot-starter-web')
   compile('net.logstash.logback:logstash-logback-encoder:4.6')
+  compile('org.springframework.boot:spring-boot-starter-hateoas')
   compile('org.slf4j:slf4j-api:1.7.+')
   compile('ch.qos.logback:logback-classic:1.+')
   compile('org.projectlombok:lombok:1.16.16')

--- a/generators/rest/index.js
+++ b/generators/rest/index.js
@@ -1,0 +1,79 @@
+var Generator = require('yeoman-generator');
+var shelljs = require('shelljs');
+var chalk = require('chalk');
+
+module.exports = class extends Generator {
+    // Helper methods
+    _buildConfiguration(answers) {
+        var configuration = {};
+
+        for (var answer in answers) {
+            if (answers.hasOwnProperty(answer)) {
+                configuration[answer] = answers[answer];
+            }
+        }
+
+        return configuration;
+    }
+
+    _folders(configuration) {
+        var defaultPackage = configuration.defaultPackage;
+        var defaultPackageFolder = defaultPackage.replace(/\./g, '/');
+
+        return {
+            main: {
+                java: 'src/main/java/' + defaultPackageFolder + '/',
+                resources: 'src/main/resources/'
+            },
+            test: {
+                java: 'src/test/java/' + defaultPackageFolder + '/',
+                resources: 'src/test/resources/'
+            },
+        };
+    }
+
+    // Task methods
+    initializing() {
+        var banner = "\n" +
+            "  __  __                _     _       _        \n" +
+            " |  \\/  | __ _  ___ ___| |__ (_) __ _| |_ ___  \n" +
+            " | |\\/| |/ _` |/ __/ __| '_ \\| |/ _` | __/ _ \\ \n" +
+            " | |  | | (_| | (_| (__| | | | | (_| | || (_) |\n" +
+            " |_|  |_|\\__,_|\\___\\___|_| |_|_|\\__,_|\\__\\___/ \n" +
+            "                                               \n";
+        this.log(chalk.green(banner));
+    }
+
+    prompting() {
+        var questions = [
+            {
+                type: "input",
+                name: "defaultPackage",
+                message: "What's the package that you want to create the rest template?"
+            },
+            {
+                type: "input",
+                name: "restClassName",
+                message: "What's the entity name to create the controller?"
+            }
+
+        ];
+
+        return this
+            .prompt(questions)
+            .then((answers) => {
+            this.configuration = this._buildConfiguration(answers);
+    })
+        ;
+    }
+
+    writing() {
+        var folders = this._folders(this.configuration);
+
+        this.fs.copyTpl(
+            this.templatePath('RestController.java'),
+            this.destinationPath(folders.main.java + this.configuration['restClassName'] +'RestController.java'),
+            this.configuration
+        );
+    }
+};

--- a/generators/rest/templates/RestController.java
+++ b/generators/rest/templates/RestController.java
@@ -1,0 +1,63 @@
+package <%=defaultPackage%>;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+public class <%=restClassName%>RestController {
+
+    @GetMapping
+    @ResponseStatus(OK)
+    public <%=restClassName%> get(@RequestParam("id") String id) {
+        //TODO: fetch the data from service layer.
+        return <%=restClassName%>.from(id);
+    }
+
+    @PostMapping(consumes = APPLICATION_JSON_VALUE)
+    @ResponseStatus(CREATED)
+    public <%=restClassName%> create(@RequestBody <%=restClassName%> resource) {
+        //TODO: goes to service layer to create the entity.
+        return <%=restClassName%>.createSelfLink(resource);
+    }
+
+    @DeleteMapping
+    @ResponseStatus(NO_CONTENT)
+    public void delete(@RequestParam("id") String id) {
+        //TODO: Goes to service layer and delete the entity.
+    }
+
+    @AllArgsConstructor
+    @Getter
+    private static class <%=restClassName%> extends ResourceSupport {
+        private final UUID resourceId;
+
+        private static <%=restClassName%> from(String id) {
+            <%=restClassName%> resource = new <%=restClassName%>(UUID.fromString(id));
+            resource.add(linkTo(methodOn(<%=restClassName%>RestController.class)
+                    .get(id))
+                    .withSelfRel());
+            return resource;
+        }
+
+        private static <%=restClassName%> createSelfLink(<%=restClassName%> resource) {
+            return from(resource.getResourceId().toString());
+        }
+    }
+}


### PR DESCRIPTION
**Why this change is needed?**
When someone need to prototype a project, sometimes it needs a rest
endpoint to perform some actions. This pr intent to create a
template for the developer to use.

**How this commit address this issue?**
It create a new generator inside macchiato. To run `yo macchiato:rest`.

___

<img width="590" alt="screen shot 2017-07-26 at 23 23 01" src="https://user-images.githubusercontent.com/7951799/28651660-824ab316-7259-11e7-896d-a42bce404ac3.png">


___


### It will create a similar Rest Controller:

```java
@RestController
public class UserRestController {

    @GetMapping
    @ResponseStatus(OK)
    public User get(@RequestParam("id") String id) {
        //TODO: fetch the data from service layer.
        return User.from(id);
    }

    @PostMapping(consumes = APPLICATION_JSON_VALUE)
    @ResponseStatus(CREATED)
    public User create(@RequestBody User resource) {
        //TODO: goes to service layer to create the entity.
        return User.createSelfLink(resource);
    }

    @DeleteMapping
    @ResponseStatus(NO_CONTENT)
    public void delete(@RequestParam("id") String id) {
        //TODO: Goes to service layer and delete the entity.
    }

    @AllArgsConstructor
    @Getter
    private static class User extends ResourceSupport {
        private final UUID resourceId;

        private static User from(String id) {
            User resource = new User(UUID.fromString(id));
            resource.add(linkTo(methodOn(UserRestController.class)
                    .get(id))
                    .withSelfRel());
            return resource;
        }

        private static User createSelfLink(User resource) {
            return from(resource.getResourceId().toString());
        }
    }
}
```
