### PR TITLE
Add Hamcrest  and Add all jars to gitignore excluding gradle wrapper.

### DIFF
--- a/generators/app/templates/build.gradle
+++ b/generators/app/templates/build.gradle
@@ -32,5 +32,6 @@ dependencies {
           <%}%>
   testCompile('org.springframework.boot:spring-boot-starter-test')
   testCompile('org.assertj:assertj-core:3.4.0')
+  testCompile('org.hamcrest:hamcrest-all:1.3')
   testCompile('com.jayway.jsonpath:json-path:2.2.0')
 }

--- a/generators/app/templates/gitignore
+++ b/generators/app/templates/gitignore
@@ -9,3 +9,7 @@ build/
 
 # Gradle
 .gradle/
+
+# Java
+*.jar
+!gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
**Why this change is needed?**
- As it's by default to unit test controller using MockMvc from Spring,
MockMvc needs to assert the Hamcrest library.

- When we create a new project that it's using java, we need to exclude
all jars, except the gradle wrapper jar because it's used to run the
build in other machines.

**How this commit address this issue?**
- It adds the Hamcrest dependency.

- It add inside of the .gitignore file a regular expression for all jars
and another one to exclude the gradle wrapper jar.