### PR TITLE
Create GitHub repository

### DIFF
--- a/generators/cloud/index.js
+++ b/generators/cloud/index.js
@@ -1,0 +1,83 @@
+var Generator = require('yeoman-generator');
+var GitHubApi = require('github-api');
+var shelljs = require('shelljs');
+
+module.exports = class extends Generator {
+  _buildConfiguration(answers) {
+    var configuration = {};
+
+    for (var answer in answers) {
+      if (answers.hasOwnProperty(answer)) {
+        configuration[answer] = answers[answer];
+      }
+    }
+
+    return configuration;
+  }
+
+  _createGitHubRepository(configuration) {
+    var github = new GitHubApi({
+      username: configuration.githubUsername,
+      password: configuration.githubPassword
+    });
+
+    var user = github.getUser();
+
+    return user.createRepo(
+      {
+        name: configuration.githubRepository
+      }
+    );
+  }
+
+  _buildAddRemoteCommand(configuration) {
+    return 'git remote add origin "https://' +
+      this.configuration.githubUsername + ':' +
+      this.configuration.githubPassword + '@' +
+      'github.com/' +
+      this.configuration.githubUsername + '/' +
+      this.configuration.githubRepository + '"';
+  }
+
+  prompting() {
+    var questions = [
+      {
+        type: "input",
+        name: "githubRepository",
+        message: "What's the GitHub repository name?"
+      },
+      {
+        type: "input",
+        name: "githubUsername",
+        message: "What's your GitHub username?",
+        store: true
+      },
+      {
+        type: "password",
+        name: "githubPassword",
+        message: "What's your GitHub password?",
+        store: true
+      }
+    ];
+
+    return this
+      .prompt(questions)
+      .then((answers) => {
+        this.configuration = this._buildConfiguration(answers);
+      });
+  }
+
+  writing() {
+    this.log('Creating GitHub remote repository');
+    var repoPromise = this._createGitHubRepository(this.configuration);
+
+    repoPromise.then((response) => {
+      this.log('Pushing to GitHub remote repository');
+      var addRemoteCommand = this._buildAddRemoteCommand(this.configuration);
+      shelljs.exec(addRemoteCommand, {silent: true});
+
+      shelljs.exec('git push origin master', {silent: true});
+
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   ],
   "author": "Guilherme Dias",
   "license": "MIT",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/guilhermedias/generator-java-service.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/guilhermedias/generator-java-service.git"
   },
   "files": [
     "generators"
@@ -17,6 +17,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "shelljs": "^0.7.8",
+    "github-api": "^3.0.0",
     "yeoman-generator": "^1.1.1"
   }
 }


### PR DESCRIPTION
**Why is this change needed?**
As part of the production enablement process using GitHub, Travis and Heroku, the user has to manually create a remote repository on GitHub and push the application code.

**How does this pull request address that?**
This commit adds the capability of automatically creating the remote repository on GitHub as part of the cloud sub-generator.

**How to use the new sub-generator**

Once you have generated the project using the standard generator, you can invoke the cloud sub-generator to have your project pushed to GitHub like that:

`$ yo macchiato: cloud`

<img width="499" alt="cloud-generator" src="https://user-images.githubusercontent.com/2279042/29040946-5e7a806a-7b87-11e7-8593-789b0de95401.png">
