### PR TITLE
Add Guava Dependence on the Main Generator #27

### DIFF
--- a/generators/app/templates/build.gradle
+++ b/generators/app/templates/build.gradle
@@ -30,6 +30,8 @@ dependencies {
   <% if(dbType != "none") {%>
   compile('org.postgresql:postgresql:42.1.1')
           <%}%>
+  compile('com.google.guava:guava:23.0')
+
   testCompile('org.springframework.boot:spring-boot-starter-test')
   testCompile('org.assertj:assertj-core:3.4.0')
   testCompile('org.hamcrest:hamcrest-all:1.3')


### PR DESCRIPTION
I want to resolve #27 

**Why this change is needed?**
Guava is a very popular library and it's very used in the community.

**How this commit address this issue?**
It adds the guava dependence into the main `build.gradle` file.