### PR TITLE
Add default profile to be equals to local

### DIFF
--- a/generators/app/templates/java/PropertiesConfiguration.java
+++ b/generators/app/templates/java/PropertiesConfiguration.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@Profile("local")
+@Profile({"default", "local"})
 @PropertySource("application-local.properties")
 public class PropertiesConfiguration {
 }

--- a/generators/app/templates/resources/logback.xml
+++ b/generators/app/templates/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration debug="false">
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
-    <springProfile name="local, test">
+    <springProfile name="default, local, test">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
                 <pattern>[%level]-[%mdc]-[%thread]-[%date{dd MMM yyyy;HH:mm:ss.SSS,UTC}]-[%logger{0}:%method:%line] -
@@ -32,7 +32,7 @@
     </springProfile>
 
     <appender name="SERVER_CONSOLE_ALL" class="ch.qos.logback.classic.AsyncAppender">
-        <springProfile name="local, test">
+        <springProfile name="default, local, test">
             <appender-ref ref="CONSOLE"/>
         </springProfile>
         <springProfile name="production">


### PR DESCRIPTION
I want to resolve #28 .

**Why this change is needed?**
it someone will run the project inside a IDE, and don't want to specify
inside of the IDE which profile the developer wants too use it, we are
going to assume that the developer wants to use local profile, but for that
to work, if the developer do not specify the profile spring will set as
default, as the project it was already set to only work with local or
production it will break when it's starts. With this commit if the developer does not set a profile it will use as default.

**How this commit address this issue?**
It set default profile as local when none profile was set.