### PR TITLE
Remove whitelabel from project

### DIFF
--- a/generators/app/templates/resources/application.properties
+++ b/generators/app/templates/resources/application.properties
@@ -4,3 +4,4 @@ spring.datasource.username=${DATABASE_USERNAME}
 spring.datasource.password=${DATABASE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 management.security.enabled=false
+server.error.whitelabel.enabled=false


### PR DESCRIPTION
I want to resolve #30 

**Why this change is needed?**
When a error occur the default behavior from spring is to display a
White Label page and as this is for a backend server the most of the
times when someone request from a browser we want to see the json
displayed.

**How this commit address this issue?**
It disable whitelabel on `application,properties`.