### PR TITLE
Add GlobalExceptionHandler to provide generic Handlers #29

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -169,6 +169,12 @@ module.exports = class extends Generator {
         );
 
         this.fs.copyTpl(
+            this.templatePath('java/GlobalExceptionHandler.java'),
+            this.destinationPath(folders.main.java + '/controller/GlobalExceptionHandler.java'),
+            this.configuration
+        );
+
+        this.fs.copyTpl(
             this.templatePath('java/annotation/*.java'),
             this.destinationPath(folders.main.java + '/annotation/'),
             this.configuration

--- a/generators/app/templates/java/GlobalExceptionHandler.java
+++ b/generators/app/templates/java/GlobalExceptionHandler.java
@@ -1,0 +1,7 @@
+package <%=defaultPackage%>.controller;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {}


### PR DESCRIPTION
I want to resolve #29 

**Why this change is needed?**
With this commit, we are introducing a global exception handler that
will give for us a handler for spring exceptions. Instead of always sent
a 500 error, with this it will address the correct handler for each type
of exception.

**How this commit address this issue?**
It adds a ControllerAdvice in the application extendig a generic
exception handler provided by Spring.