### PR TITLE
Remove files and code if db is not select weren't used #32

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -161,6 +161,12 @@ module.exports = class extends Generator {
                 this.destinationPath('gradle/scripts/'),
                 this.configuration
             );
+
+            this.fs.copyTpl(
+                this.templatePath('resources/flyway/*.sql'),
+                this.destinationPath(folders.main.resources + '/db/migration/'),
+                this.configuration
+            );
         }
         this.fs.copyTpl(
             this.templatePath('java/advice/*.java'),
@@ -183,12 +189,6 @@ module.exports = class extends Generator {
         this.fs.copyTpl(
             this.templatePath('resources/logback.xml'),
             this.destinationPath(folders.main.resources + 'logback.xml'),
-            this.configuration
-        );
-
-        this.fs.copyTpl(
-            this.templatePath('resources/flyway/*.sql'),
-            this.destinationPath(folders.main.resources + '/db/migration/'),
             this.configuration
         );
     }

--- a/generators/app/templates/build.gradle
+++ b/generators/app/templates/build.gradle
@@ -21,14 +21,14 @@ dependencies {
   compile('org.slf4j:slf4j-api:1.7.+')
   compile('ch.qos.logback:logback-classic:1.+')
   compile('org.projectlombok:lombok:1.16.16')
-  compile('org.flywaydb:flyway-core:4.2.0')
 
   compile('org.springframework.boot:spring-boot-starter-actuator')
   <% if(dbType == "jpa") {%>compile('org.springframework.boot:spring-boot-starter-data-jpa')
-  <%}else{ if(dbType == "jdbc"){%>
-  compile('org.springframework.boot:spring-boot-starter-jdbc')<%}}%>
+    <%}else{ if(dbType == "jdbc"){%>
+    compile('org.springframework.boot:spring-boot-starter-jdbc')<%}}%>
   <% if(dbType != "none") {%>
-  compile('org.postgresql:postgresql:42.1.1')
+    compile('org.flywaydb:flyway-core:4.2.0')
+    compile('org.postgresql:postgresql:42.1.1')
           <%}%>
   compile('com.google.guava:guava:23.0')
 

--- a/generators/app/templates/resources/application-local.properties
+++ b/generators/app/templates/resources/application-local.properties
@@ -1,3 +1,6 @@
+#Add your local properties here.
+<% if(dbType != "none") {%>
 DATABASE_URL=jdbc:postgresql://localhost:8092/<%=applicationName%>
 DATABASE_USERNAME=postgres
 DATABASE_PASSWORD=postgres
+<%}%>

--- a/generators/app/templates/resources/application-test.properties
+++ b/generators/app/templates/resources/application-test.properties
@@ -1,3 +1,6 @@
+#Add your test properties here.
+<% if(dbType != "none") {%>
 DATABASE_URL=jdbc:postgresql://localhost:8092/<%=applicationName%>
 DATABASE_USERNAME=postgres
 DATABASE_PASSWORD=postgres
+<%}%>

--- a/generators/app/templates/resources/application.properties
+++ b/generators/app/templates/resources/application.properties
@@ -1,7 +1,9 @@
 application.name=<%=applicationName%>
+<% if(dbType != "none") {%>
 spring.datasource.url=${DATABASE_URL}
 spring.datasource.username=${DATABASE_USERNAME}
 spring.datasource.password=${DATABASE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
+<%}%>
 management.security.enabled=false
 server.error.whitelabel.enabled=false

--- a/generators/app/templates/travis.yml
+++ b/generators/app/templates/travis.yml
@@ -1,8 +1,9 @@
 sudo: required
 language: java
 jdk: oraclejdk8
+<% if(dbType != "none") {%>
 services:
-  - docker
+  - docker<%}%>
 deploy:
   provider: heroku
   app: <%=applicationName%>


### PR DESCRIPTION
I want to resolve #32 

**Why this change is needed?**
it was a bug when the developer selects to create a project without db,
macchiato was generating files and properties that would only be used if
the application was using db.

**How this commit address this issue?**
It removes all files and properties that was only used by db.